### PR TITLE
update notification on add tracking history

### DIFF
--- a/Entity/Notification.php
+++ b/Entity/Notification.php
@@ -555,6 +555,7 @@ class Notification
     public function addTrackingHistory(\IDCI\Bundle\NotificationBundle\Entity\TrackingHistory $trackingHistory)
     {
         $this->trackingHistories[] = $trackingHistory;
+        $this->onUpdate();
 
         return $this;
     }


### PR DESCRIPTION
To refresh notification indexing when creating a tracking history. the notification must be updated