### PR TITLE
Add priority to notifications

### DIFF
--- a/Command/NotificationCommand.php
+++ b/Command/NotificationCommand.php
@@ -43,7 +43,13 @@ EOT
         $notificationManager = $this->getContainer()->get('idci_notification.manager.notification');
 
         $countErrors = 0;
-        $notifications = $notificationManager->findBy(array('status' => Notification::STATUS_NEW));
+        $notifications = $notificationManager->findBy(
+            array('status' => Notification::STATUS_NEW),
+            array(
+                'priority' => 'DESC',
+                'id' => 'ASC',
+            )
+        );
         $output->writeln(sprintf('<info>Send notifications (%d)</info>', count($notifications)));
         foreach ($notifications as $notification) {
             $notificationManager->notify($notification);

--- a/Controller/Api/NotificationController.php
+++ b/Controller/Api/NotificationController.php
@@ -55,7 +55,7 @@ class NotificationController extends FOSRestController
         $notificationData = $rawData['data'];
         $notificationFiles = $this->get('request')->files->all();
 
-        $priority = $priority = Notification::PRIORITY_NORMAL;
+        $priority = Notification::PRIORITY_NORMAL;
         if (isset($rawData['priority'])) {
             $priority = $rawData['priority'];
         }

--- a/Controller/Api/NotificationController.php
+++ b/Controller/Api/NotificationController.php
@@ -55,10 +55,15 @@ class NotificationController extends FOSRestController
         $notificationData = $rawData['data'];
         $notificationFiles = $this->get('request')->files->all();
 
+        $priority = $priority = Notification::PRIORITY_NORMAL;
+        if (isset($rawData['priority'])) {
+            $priority = $rawData['priority'];
+        }
+
         try {
             $this
                 ->get('idci_notification.manager.notification')
-                ->addNotification($notifierAlias, $notificationData, $notificationFiles, $sourceName)
+                ->addNotification($notifierAlias, $notificationData, $notificationFiles, $sourceName, $priority)
             ;
         } catch (UndefinedNotifierException $e) {
             $this->get('logger')->error($e->getMessage());

--- a/Entity/Notification.php
+++ b/Entity/Notification.php
@@ -17,6 +17,8 @@ use IDCI\Bundle\NotificationBundle\Exception\NotificationFieldParseErrorExceptio
  * @ORM\Entity(repositoryClass="IDCI\Bundle\NotificationBundle\Entity\Repository\NotificationRepository")
  * @ORM\Table(name="notification", indexes={
  *    @ORM\Index(name="notification_status", columns={"status"}),
+ *    @ORM\Index(name="notification_priority", columns={"priority"}),
+ *    @ORM\Index(name="notification_status_priority", columns={"status", "priority"}),
  *    @ORM\Index(name="notification_source", columns={"source"}),
  *    @ORM\Index(name="notification_alias", columns={"notifier_alias"}),
  *    @ORM\Index(name="notification_created_at", columns={"created_at"}),
@@ -30,6 +32,10 @@ class Notification
     const STATUS_DONE = 'DONE';
     const STATUS_ERROR = 'ERROR';
     const STATUS_PENDING = 'PENDING';
+
+    const PRIORITY_LOW = -1;
+    const PRIORITY_NORMAL = 0;
+    const PRIORITY_HIGH = 1;
 
     /**
      * @var int
@@ -56,6 +62,12 @@ class Notification
      * @ORM\Column(type="string", length=64, nullable=false)
      */
     protected $status;
+
+    /**
+     * @var string
+     * @ORM\Column(type="integer", length=64, nullable=false)
+     */
+    protected $priority = self::PRIORITY_NORMAL;
 
     /**
      * @var string
@@ -129,6 +141,20 @@ class Notification
             self::STATUS_DONE => self::STATUS_DONE,
             self::STATUS_ERROR => self::STATUS_ERROR,
             self::STATUS_PENDING => self::STATUS_PENDING,
+        );
+    }
+
+    /**
+     * Get priority list.
+     *
+     * @return array
+     */
+    public static function getPriorityList()
+    {
+        return array(
+            self::PRIORITY_LOW => self::PRIORITY_LOW,
+            self::PRIORITY_NORMAL => self::PRIORITY_NORMAL,
+            self::PRIORITY_HIGH => self::PRIORITY_HIGH,
         );
     }
 
@@ -285,6 +311,30 @@ class Notification
     public function getStatus()
     {
         return $this->status;
+    }
+
+    /**
+     * Set priority.
+     *
+     * @param string $priority
+     *
+     * @return Notification
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+
+        return $this;
+    }
+
+    /**
+     * Get priority.
+     *
+     * @return string
+     */
+    public function getPriority()
+    {
+        return $this->priority;
     }
 
     /**

--- a/Form/NotificationType.php
+++ b/Form/NotificationType.php
@@ -23,6 +23,9 @@ class NotificationType extends AbstractType
             ->add('status', 'choice', array(
                 'choices' => Notification::getStatusList(),
             ))
+            ->add('priority', 'choice', array(
+                'choices' => Notification::getPriorityList()
+            ))
             ->add('type', 'notifier_choice')
             ->add('notifierAlias')
             ->add('from')

--- a/Manager/NotificationManager.php
+++ b/Manager/NotificationManager.php
@@ -168,9 +168,15 @@ class NotificationManager extends AbstractManager
      * @param string      $data       Notification data in json format.
      * @param array       $files      Notification files.
      * @param string|null $sourceName Notification source name.
+     * @param integer     $priority   The notification priority.
      */
-    public function addNotification($alias, $data, array $files, $sourceName = null)
-    {
+    public function addNotification(
+        $alias,
+        $data,
+        array $files,
+        $sourceName = null,
+        $priority = Notification::PRIORITY_NORMAL
+    ) {
         $notifier = $this->getNotifier($alias);
 
         $decodedData = json_decode($data, true);
@@ -193,6 +199,7 @@ class NotificationManager extends AbstractManager
             ->setTo(isset($data['to']) ? json_encode($data['to']) : null)
             ->setContent(json_encode($data['content']))
             ->setFiles($movedFiles)
+            ->setPriority($priority)
         ;
 
         $this->getObjectManager()->persist($notification);


### PR DESCRIPTION
This PR will add 3 levels of priority for a notification: low(-1), normal(0) and high(1). So the idci:notification:send command will order the notifications and these with high priority will always be sended firsts, low priority notification will be sended lasts.

In order to work properly, a database update is required:
> ALTER TABLE notification ADD priority INT NOT NULL;
CREATE INDEX notification_priority ON notification (priority);
CREATE INDEX notification_status_priority ON notification (status, priority);