### PR TITLE
Add the limit option to idci:notification:send command

### DIFF
--- a/Command/NotificationCommand.php
+++ b/Command/NotificationCommand.php
@@ -10,6 +10,7 @@ namespace IDCI\Bundle\NotificationBundle\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use IDCI\Bundle\NotificationBundle\Entity\Notification;
@@ -24,9 +25,14 @@ class NotificationCommand extends ContainerAwareCommand
         $this
             ->setName('idci:notification:send')
             ->setDescription('Send notification from spool')
+            ->addOption('limit', null, InputOption::VALUE_OPTIONAL, 'Limit the number of notification sent')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command sends all notifications and show in the console a detail of notifications sent.
-Here is an example of usage of this command <info>php app/console tms:notification:send</info>
+Here is an example of usage of this command <info>php app/console %command.name%</info>
+
+To send an limited number of notifications on each run, you can use the optionnal application parameter <info>idci_notification.batch.limit</info> or use the limit option of this command.
+The example below will send 10 firsts notifications:
+    <info>php app/console %command.name% --limit=10</info>
 EOT
             )
         ;
@@ -41,9 +47,21 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $notificationManager = $this->getContainer()->get('idci_notification.manager.notification');
+        $options = $input->getOptions();
+
+        $limit = null;
+        if ($options['limit']) {
+            $limit = $options['limit'];
+        } elseif ($this->getContainer()->hasParameter('idci_notification.batch.limit')) {
+            $limit = $this->getContainer()->getParameter('idci_notification.batch.limit');
+        }
 
         $countErrors = 0;
-        $notifications = $notificationManager->findBy(array('status' => Notification::STATUS_NEW));
+        $notifications = $notificationManager->findBy(
+            array('status' => Notification::STATUS_NEW),
+            array(),
+            $limit
+        );
         $output->writeln(sprintf('<info>Send notifications (%d)</info>', count($notifications)));
         foreach ($notifications as $notification) {
             $notificationManager->notify($notification);

--- a/Command/NotificationCommand.php
+++ b/Command/NotificationCommand.php
@@ -49,11 +49,9 @@ EOT
         $notificationManager = $this->getContainer()->get('idci_notification.manager.notification');
         $options = $input->getOptions();
 
-        $limit = null;
+        $limit = $this->getContainer()->getParameter('idci_notification.batch.limit');
         if ($options['limit']) {
             $limit = $options['limit'];
-        } elseif ($this->getContainer()->hasParameter('idci_notification.batch.limit')) {
-            $limit = $this->getContainer()->getParameter('idci_notification.batch.limit');
         }
 
         $countErrors = 0;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,6 +46,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('files_directory')->defaultNull()->end()
                 ->scalarNode('mirror_link_url')->defaultNull()->end()
                 ->scalarNode('tracking_url')->defaultNull()->end()
+                ->integerNode('batch_limit')->defaultNull()->end()
             ->end()
         ;
 

--- a/DependencyInjection/IDCINotificationExtension.php
+++ b/DependencyInjection/IDCINotificationExtension.php
@@ -55,5 +55,10 @@ class IDCINotificationExtension extends Extension
             'idci_notification.tracking_url',
             $config['tracking_url']
         );
+
+        $container->setParameter(
+            'idci_notification.batch.limit',
+            $config['batch_limit']
+        );
     }
 }


### PR DESCRIPTION
Currently, the idci:notification:send retrieve all the new notifications, with can be problematic in case of a massive notification campaign.
With this PR, we can specify a --limit option or use a global parameter idci_notification.batch.limit (witch is optionnal) to send a limited number of notification.